### PR TITLE
Pull request of bug 922014, bug 922526

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -147,6 +147,7 @@ COMMON_LIBS="
 	libcm.so
 	libcameraservice.so
 	libcamera_client.so
+	libchromatix_ov5647_preview.so
 	libhwdevctl_client.so
 	libhwdevctlservice.so
 	libCommandSvc.so


### PR DESCRIPTION
Bug 922014 - Add libchromatix_ov5647_preview.so into extract-files.sh. r=mchen
Bug 922526 - Copy vold.fstab from external_sd.fstab to make internal storage work. r=mchen
