### PR TITLE
removed wiperiface

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -222,6 +222,7 @@ COMMON_LIBS="
 
 copy_files "$COMMON_LIBS" "system/lib" ""
 
+# removed wiperiface
 COMMON_BINS="
 	akmd8963
 	akmd8975
@@ -242,7 +243,6 @@ COMMON_BINS="
 	wlan_detect
 	hwdevctlservice
 	gpu_dcvsd
-	wiperiface
 	callife
 	ath_supplicant
 	wpa_cli


### PR DESCRIPTION
removing wiperiface from the pull request because it's not in the OEM build for 1.1
This is causing issues with the extraction process:
see https://bugzilla.mozilla.org/show_bug.cgi?id=917642#c62
